### PR TITLE
Implement control block helpers

### DIFF
--- a/src/blocks/control.ts
+++ b/src/blocks/control.ts
@@ -1,7 +1,70 @@
-import type * as sb3 from "@pnsk-lab/sb3-types"
 import { fromPrimitiveSource } from "../compiler/block-helper"
 import type { PrimitiveSource } from "../compiler/types"
 import { block, substack } from "../compiler/composer"
+
+export type StopOption =
+  | 'all'
+  | 'this script'
+  | 'other scripts in sprite'
+  | 'other scripts in stage'
+
+export type VariableField = [string, string]
+
+export const repeat = (
+  times: PrimitiveSource<number>,
+  handler: () => void
+) => {
+  const substackId = substack(handler)
+  return block('control_repeat', {
+    inputs: {
+      TIMES: fromPrimitiveSource(times),
+      ...(substackId ? { SUBSTACK: [2, substackId] } : {})
+    }
+  })
+}
+
+export const repeatUntil = (
+  condition: PrimitiveSource<boolean>,
+  handler: () => void
+) => {
+  const substackId = substack(handler)
+  return block('control_repeat_until', {
+    inputs: {
+      CONDITION: fromPrimitiveSource(condition),
+      ...(substackId ? { SUBSTACK: [2, substackId] } : {})
+    }
+  })
+}
+
+export const repeatWhile = (
+  condition: PrimitiveSource<boolean>,
+  handler: () => void
+) => {
+  const substackId = substack(handler)
+  return block('control_while', {
+    inputs: {
+      CONDITION: fromPrimitiveSource(condition),
+      ...(substackId ? { SUBSTACK: [2, substackId] } : {})
+    }
+  })
+}
+
+export const forEach = (
+  variable: VariableField,
+  value: PrimitiveSource<number>,
+  handler: () => void
+) => {
+  const substackId = substack(handler)
+  return block('control_for_each', {
+    inputs: {
+      VALUE: fromPrimitiveSource(value),
+      ...(substackId ? { SUBSTACK: [2, substackId] } : {})
+    },
+    fields: {
+      VARIABLE: variable
+    }
+  })
+}
 
 export const forever = (handler: () => void) => {
   const substackId = substack(handler)
@@ -12,3 +75,88 @@ export const forever = (handler: () => void) => {
   })
 }
 
+export const wait = (seconds: PrimitiveSource<number>) => {
+  return block('control_wait', {
+    inputs: {
+      DURATION: fromPrimitiveSource(seconds)
+    }
+  })
+}
+
+export const waitUntil = (condition: PrimitiveSource<boolean>) => {
+  return block('control_wait_until', {
+    inputs: {
+      CONDITION: fromPrimitiveSource(condition)
+    }
+  })
+}
+
+export const ifThen = (
+  condition: PrimitiveSource<boolean>,
+  handler: () => void
+) => {
+  const substackId = substack(handler)
+  return block('control_if', {
+    inputs: {
+      CONDITION: fromPrimitiveSource(condition),
+      ...(substackId ? { SUBSTACK: [2, substackId] } : {})
+    }
+  })
+}
+
+export const ifElse = (
+  condition: PrimitiveSource<boolean>,
+  thenHandler: () => void,
+  elseHandler: () => void
+) => {
+  const thenSubstackId = substack(thenHandler)
+  const elseSubstackId = substack(elseHandler)
+  return block('control_if_else', {
+    inputs: {
+      CONDITION: fromPrimitiveSource(condition),
+      ...(thenSubstackId ? { SUBSTACK: [2, thenSubstackId] } : {}),
+      ...(elseSubstackId ? { SUBSTACK2: [2, elseSubstackId] } : {})
+    }
+  })
+}
+
+export const stop = (option: StopOption) => {
+  return block('control_stop', {
+    fields: {
+      STOP_OPTION: [option, null]
+    }
+  })
+}
+
+export const createClone = (target: string) => {
+  return block('control_create_clone_of', {
+    fields: {
+      CLONE_OPTION: [target, null]
+    }
+  })
+}
+
+export const deleteThisClone = () => {
+  return block('control_delete_this_clone', {})
+}
+
+export const getCounter = () => {
+  return block('control_get_counter', {})
+}
+
+export const incrCounter = () => {
+  return block('control_incr_counter', {})
+}
+
+export const clearCounter = () => {
+  return block('control_clear_counter', {})
+}
+
+export const allAtOnce = (handler: () => void) => {
+  const substackId = substack(handler)
+  return block('control_all_at_once', {
+    inputs: substackId ? {
+      SUBSTACK: [2, substackId]
+    } : {}
+  })
+}


### PR DESCRIPTION
### Motivation

- Provide TypeScript helpers to build Scratch control blocks so higher-level code can compose control flow blocks programmatically.

### Description

- Added `src/blocks/control.ts` implementing builders for control primitives such as `repeat`, `repeatUntil`, `repeatWhile`, `forEach`, `forever`, `wait`, `waitUntil`, `ifThen`, `ifElse`, `stop`, `createClone`, `deleteThisClone`, `getCounter`, `incrCounter`, `clearCounter`, and `allAtOnce` using `block`, `substack`, and `fromPrimitiveSource`.
- Introduced `StopOption` and `VariableField` types to type the `stop` field and `forEach` variable field respectively.
- Each builder wires inputs and fields to the correct Scratch opcode shape (e.g. `SUBSTACK` value references returned from `substack` and `fromPrimitiveSource` for primitive inputs).
- Kept `forever` implementation and extended the module to provide a complete set of control helpers for composing blocks.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696edb57c0bc833293e1904e9b6872e7)