### PR TITLE
Add costume references and Target.addCostume; allow switching by costume reference

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -6,27 +6,29 @@ import { whenFlagClicked } from "../src/blocks/events";
 import { ASSET_CAT1, ASSET_CAT2 } from "../src/utils/assets";
 import { forever } from "../src/blocks/control";
 import { getMouseX } from "../src/blocks/sensing";
+import { switchCostumeTo } from "../src/blocks/looks";
 
 const project = new Project()
 
 const sprite1 = project.createSprite('スプライト1')
 
-sprite1.costumes = [
-  {
-    name: 'cat3',
-    assetId: ASSET_CAT1,
-    dataFormat: 'svg'
-  },
-  {
-    name: 'cat1',
-    assetId: ASSET_CAT2,
-    dataFormat: 'svg'
-  }
-]
+const cat3 = sprite1.addCostume({
+  name: 'cat3',
+  assetId: ASSET_CAT1,
+  dataFormat: 'svg'
+})
+
+const cat1 = sprite1.addCostume({
+  name: 'cat1',
+  assetId: ASSET_CAT2,
+  dataFormat: 'svg'
+})
 
 sprite1.run(() => {
   whenFlagClicked(() => {
+    switchCostumeTo(cat3)
     forever(() => {
+      switchCostumeTo(cat1)
       moveSteps(getMouseX())
     })
   })

--- a/src/blocks/looks.ts
+++ b/src/blocks/looks.ts
@@ -1,6 +1,6 @@
-import { fromPrimitiveSource } from "../compiler/block-helper"
+import { fromCostumeSource, fromPrimitiveSource } from "../compiler/block-helper"
 import { block } from "../compiler/composer"
-import type { PrimitiveSource } from "../compiler/types"
+import type { CostumeSource, PrimitiveSource } from "../compiler/types"
 
 export type LookEffect =
   | 'color'
@@ -63,10 +63,10 @@ export const hide = () => {
   return block('looks_hide', {})
 }
 
-export const switchCostumeTo = (costume: PrimitiveSource<string>) => {
+export const switchCostumeTo = (costume: CostumeSource) => {
   return block('looks_switchcostumeto', {
     inputs: {
-      COSTUME: fromPrimitiveSource(costume)
+      COSTUME: fromCostumeSource(costume)
     }
   })
 }

--- a/src/compiler/block-helper.ts
+++ b/src/compiler/block-helper.ts
@@ -1,5 +1,5 @@
 import * as sb3 from "@pnsk-lab/sb3-types";
-import type { PrimitiveAvailableOnScratch, PrimitiveSource } from "./types";
+import type { CostumeSource, PrimitiveAvailableOnScratch, PrimitiveSource } from "./types";
 
 export const fromPrimitiveSource = <T extends PrimitiveAvailableOnScratch>(
   source: PrimitiveSource<T>,
@@ -15,4 +15,12 @@ export const fromPrimitiveSource = <T extends PrimitiveAvailableOnScratch>(
   }
 
   return [1, source.id]
+}
+
+export const fromCostumeSource = (source: CostumeSource): sb3.Input => {
+  if (typeof source === 'object' && source !== null && 'type' in source && source.type === 'costume') {
+    return fromPrimitiveSource(source.name)
+  }
+
+  return fromPrimitiveSource(source)
 }

--- a/src/compiler/project.ts
+++ b/src/compiler/project.ts
@@ -1,6 +1,6 @@
 import type * as sb3 from "@pnsk-lab/sb3-types"
 import { createBlocks } from "./composer"
-import type { ListReference, VariableReference } from "./types"
+import type { CostumeReference, ListReference, VariableReference } from "./types"
 
 let nextAssetId = 0
 const createAssetId = () => `asset-${(++nextAssetId).toString(16)}`
@@ -8,12 +8,12 @@ const createAssetId = () => `asset-${(++nextAssetId).toString(16)}`
 export class Target<IsStage extends boolean = boolean> {
   readonly isStage: IsStage
   readonly name: IsStage extends true ? 'Stage' : string
-  costumes: sb3.Costume[] | null = null
   currentCostume = 0
 
   #blocks: Record<string, sb3.Block> = {}
   #variables: Record<string, sb3.ScalarVariable> = {}
   #lists: Record<string, sb3.List> = {}
+  #costumes: sb3.Costume[] = []
   constructor(
     isStage: IsStage,
     name: IsStage extends true ? 'Stage' : string
@@ -59,9 +59,17 @@ export class Target<IsStage extends boolean = boolean> {
     }
   }
 
+  addCostume (costume: sb3.Costume): CostumeReference {
+    this.#costumes.push(costume)
+    return {
+      name: costume.name,
+      type: 'costume' as const
+    }
+  }
+
   toScratch(): IsStage extends true ? sb3.Stage : sb3.Sprite {
-    const costumes = (this.costumes && this.costumes.length > 0)
-      ? this.costumes
+    const costumes = (this.#costumes.length > 0)
+      ? this.#costumes
       : [{
         name: this.name,
         assetId: 'cd21514d0531fdffb22204e0ec5ed84a',

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -17,6 +17,13 @@ export interface ListReference extends VariableBase {
   type: 'list'
 }
 
+export interface CostumeReference {
+  name: string
+  type: 'costume'
+}
+
+export type CostumeSource = PrimitiveSource<string> | CostumeReference
+
 export interface HikkakuBlock {
   id: string
 }


### PR DESCRIPTION
### Motivation
- Provide a first-class costume reference API so costumes can be registered via code and passed to looks blocks without mutating `target.costumes` directly.

### Description
- Introduce `CostumeReference` and `CostumeSource` types in `src/compiler/types.ts` to represent costume references and costume-compatible sources.
- Add `fromCostumeSource` helper in `src/compiler/block-helper.ts` to convert a `CostumeSource` into an `sb3.Input`.
- Update `switchCostumeTo` in `src/blocks/looks.ts` to accept `CostumeSource` and use `fromCostumeSource` when building the block.
- Add `Target.addCostume` and internal `#costumes` storage in `src/compiler/project.ts`, and make `toScratch` use the internal costume list; update `example/main.ts` to register costumes with `addCostume` and switch using the returned references.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696effa9c3a0833294d82c17be20fae8)