### PR TITLE
Add sound asset references and playback support

### DIFF
--- a/src/blocks/sound.ts
+++ b/src/blocks/sound.ts
@@ -1,21 +1,21 @@
-import { fromPrimitiveSource } from "../compiler/block-helper"
+import { fromPrimitiveSource, fromSoundSource } from "../compiler/block-helper"
 import { block } from "../compiler/composer"
-import type { PrimitiveSource } from "../compiler/types"
+import type { PrimitiveSource, SoundSource } from "../compiler/types"
 
 export type SoundEffect = 'pitch' | 'pan'
 
-export const playSound = (sound: PrimitiveSource<string>) => {
+export const playSound = (sound: SoundSource) => {
   return block('sound_play', {
     inputs: {
-      SOUND_MENU: fromPrimitiveSource(sound)
+      SOUND_MENU: fromSoundSource(sound)
     }
   })
 }
 
-export const playSoundUntilDone = (sound: PrimitiveSource<string>) => {
+export const playSoundUntilDone = (sound: SoundSource) => {
   return block('sound_playuntildone', {
     inputs: {
-      SOUND_MENU: fromPrimitiveSource(sound)
+      SOUND_MENU: fromSoundSource(sound)
     }
   })
 }

--- a/src/compiler/block-helper.ts
+++ b/src/compiler/block-helper.ts
@@ -1,5 +1,5 @@
 import * as sb3 from "@pnsk-lab/sb3-types";
-import type { CostumeSource, PrimitiveAvailableOnScratch, PrimitiveSource } from "./types";
+import type { CostumeSource, PrimitiveAvailableOnScratch, PrimitiveSource, SoundSource } from "./types";
 
 export const fromPrimitiveSource = <T extends PrimitiveAvailableOnScratch>(
   source: PrimitiveSource<T>,
@@ -19,6 +19,14 @@ export const fromPrimitiveSource = <T extends PrimitiveAvailableOnScratch>(
 
 export const fromCostumeSource = (source: CostumeSource): sb3.Input => {
   if (typeof source === 'object' && source !== null && 'type' in source && source.type === 'costume') {
+    return fromPrimitiveSource(source.name)
+  }
+
+  return fromPrimitiveSource(source)
+}
+
+export const fromSoundSource = (source: SoundSource): sb3.Input => {
+  if (typeof source === 'object' && source !== null && 'type' in source && source.type === 'sound') {
     return fromPrimitiveSource(source.name)
   }
 

--- a/src/compiler/project.ts
+++ b/src/compiler/project.ts
@@ -1,6 +1,6 @@
 import type * as sb3 from "@pnsk-lab/sb3-types"
 import { createBlocks } from "./composer"
-import type { CostumeReference, ListReference, VariableReference } from "./types"
+import type { CostumeReference, ListReference, SoundReference, VariableReference } from "./types"
 
 let nextAssetId = 0
 const createAssetId = () => `asset-${(++nextAssetId).toString(16)}`
@@ -14,6 +14,7 @@ export class Target<IsStage extends boolean = boolean> {
   #variables: Record<string, sb3.ScalarVariable> = {}
   #lists: Record<string, sb3.List> = {}
   #costumes: sb3.Costume[] = []
+  #sounds: sb3.Sound[] = []
   constructor(
     isStage: IsStage,
     name: IsStage extends true ? 'Stage' : string
@@ -67,6 +68,14 @@ export class Target<IsStage extends boolean = boolean> {
     }
   }
 
+  addSound (sound: sb3.Sound): SoundReference {
+    this.#sounds.push(sound)
+    return {
+      name: sound.name,
+      type: 'sound' as const
+    }
+  }
+
   toScratch(): IsStage extends true ? sb3.Stage : sb3.Sprite {
     const costumes = (this.#costumes.length > 0)
       ? this.#costumes
@@ -80,7 +89,7 @@ export class Target<IsStage extends boolean = boolean> {
       broadcasts: {},
       variables: this.#variables,
       lists: this.#lists,
-      sounds: [],
+      sounds: this.#sounds,
       currentCostume: this.currentCostume,
       costumes
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -24,6 +24,13 @@ export interface CostumeReference {
 
 export type CostumeSource = PrimitiveSource<string> | CostumeReference
 
+export interface SoundReference {
+  name: string
+  type: 'sound'
+}
+
+export type SoundSource = PrimitiveSource<string> | SoundReference
+
 export interface HikkakuBlock {
   id: string
 }


### PR DESCRIPTION
### Motivation
- Enable sound assets to be referenced and reused similarly to costumes so playback blocks can accept either literal names or registered sound assets.
- Provide a way for targets to register sounds into the project output so exported Scratch projects include sound metadata.
- Keep input resolution consistent across costumes and sounds by introducing a helper to convert sound sources to Scratch `sb3.Input` values.

### Description
- Added `SoundReference` and `SoundSource` types to `src/compiler/types.ts` to model sound assets and sources (`SoundReference`, `SoundSource`).
- Implemented `fromSoundSource` in `src/compiler/block-helper.ts` to resolve `SoundSource` values to `sb3.Input` values following the `fromCostumeSource` pattern.
- Extended `Target` in `src/compiler/project.ts` with a private `#sounds: sb3.Sound[]` array, an `addSound(sound: sb3.Sound): SoundReference` method, and included `sounds` in the `toScratch()` output.
- Updated playback blocks in `src/blocks/sound.ts` to accept `SoundSource` and to use `fromSoundSource` for the `SOUND_MENU` input in `playSound` and `playSoundUntilDone`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f06b4faf88332b8e9aaa798dce45e)