### PR TITLE
feat(control): add match helper and docs

### DIFF
--- a/packages/hikkaku/src/blocks/control.ts
+++ b/packages/hikkaku/src/blocks/control.ts
@@ -117,6 +117,45 @@ export const ifElse = (
   })
 }
 
+export const match = (
+  ...a:
+    | [condition: PrimitiveSource<boolean>, handler: () => void][]
+    | [
+        ...[condition: PrimitiveSource<boolean>, handler: () => void][],
+        () => void,
+      ]
+) => {
+  if (a.length === 0) {
+    return
+  }
+
+  const tail = a[a.length - 1]
+  const defaultHandler = typeof tail === 'function' ? tail : null
+  const branches = (defaultHandler ? a.slice(0, -1) : a) as [
+    PrimitiveSource<boolean>,
+    () => void,
+  ][]
+
+  if (branches.length === 0) {
+    return defaultHandler?.()
+  }
+
+  let elseHandler: () => void = defaultHandler ?? (() => {})
+  for (let i = branches.length - 1; i >= 0; i--) {
+    const branch = branches[i]
+    if (!branch) {
+      continue
+    }
+    const [condition, handler] = branch
+    const next = elseHandler
+    elseHandler = () => {
+      ifElse(condition, handler, next)
+    }
+  }
+
+  return elseHandler()
+}
+
 export const stop = (option: StopOption) => {
   return block('control_stop', {
     fields: {

--- a/packages/skill/rules/blocks/control.md
+++ b/packages/skill/rules/blocks/control.md
@@ -67,6 +67,13 @@ If / else branching.
 * `thenHandler: () => void`
 * `elseHandler: () => void`
 
+## match(...branches)
+
+Builds chained if / else-if / else branching from condition-handler pairs.
+
+* `...branches: [condition: PrimitiveSource<boolean>, handler: () => void][] | [...[condition: PrimitiveSource<boolean>, handler: () => void][], () => void]`
+* If the last argument is `() => void`, it is used as the default (`else`) branch.
+
 ## stop(option)
 
 Stops scripts.


### PR DESCRIPTION
## Summary
- implement `match` in `packages/hikkaku/src/blocks/control.ts`
- build nested branching via `ifElse` with optional default handler
- document `match(...branches)` in `packages/skill/rules/blocks/control.md`

## Validation
- `bunx biome check packages/hikkaku/src/blocks/control.ts`