### PR TITLE
fix: refresh bun.lock for frozen installs (include examples/rectangle)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "hikkaku-workspace",
@@ -62,6 +61,16 @@
     },
     "examples/json-parser": {
       "name": "example-json-parser",
+      "dependencies": {
+        "hikkaku": "workspace:*",
+      },
+      "devDependencies": {
+        "@typescript/native-preview": "^7.0.0-dev.20260127.1",
+        "vite": "8.0.0-beta.8",
+      },
+    },
+    "examples/rectangle": {
+      "name": "rectangle-example",
       "dependencies": {
         "hikkaku": "workspace:*",
       },
@@ -561,6 +570,8 @@
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "rectangle-example": ["rectangle-example@workspace:examples/rectangle"],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 


### PR DESCRIPTION
### Motivation
- Deployment runs of `bun i --frozen-lockfile` were failing due to a lockfile/workspace mismatch where the `examples/rectangle` workspace was not represented in the lockfile.

### Description
- Regenerated `bun.lock` using Bun v1.2.14 and removed an outdated lockfile metadata field that Bun rewrites (`configVersion`).
- Added a `workspaces` entry for `examples/rectangle` with the declared name `rectangle-example` so the workspace is tracked in the lockfile.
- Added the corresponding package map entry `rectangle-example@workspace:examples/rectangle` to pin resolution for that example.

### Testing
- Verified `bun --version` is `1.2.14`.
- Ran `bun i --frozen-lockfile` and the install completed successfully (no changes reported, exit 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b383cf6688332b3ee9635d8f3310f)