### PR TITLE
feat(procedures): add reference-based procedure call API

### DIFF
--- a/docs/guides/custom-blocks.md
+++ b/docs/guides/custom-blocks.md
@@ -32,7 +32,7 @@ sprite.run(() => {
       }
     )
 
-    callProcedure(greet.reference, [
+    callProcedure(greet, [
       { reference: greet.reference.arguments.name, value: 'Ada' },
       { reference: greet.reference.arguments.excited, value: true }
     ])
@@ -55,7 +55,7 @@ const greet = defineProcedure([
 ])
 
 // Recommended: reference-based invocation.
-callProcedure(greet.reference, [
+callProcedure(greet, [
   { reference: greet.reference.arguments.name, value: 'Ada' }
 ])
 

--- a/docs/reference/blocks/procedures.md
+++ b/docs/reference/blocks/procedures.md
@@ -79,7 +79,7 @@ defineProcedure(list as any, () => {}, undefined as any)
 
 Calls a custom procedure.
 
-Input: either (`proccode`, `argumentIds`, `inputs`, `warp`) or (`reference`, `inputsByReference`, `warp`).
+Input: either (`proccode`, `argumentIds`, `inputs`, `warp`) or (`definitionOrReference`, `inputsByReference`, `warp`).
 
 Output: Scratch statement block definition that is appended to the current script stack.
 

--- a/packages/hikkaku/src/blocks/procedures.ts
+++ b/packages/hikkaku/src/blocks/procedures.ts
@@ -1,6 +1,6 @@
 import { fromPrimitiveSource } from '../core/block-helper'
 import { attachStack, block, valueBlock } from '../core/composer'
-import type { PrimitiveSource } from '../core/types'
+import type { HikkakuBlock, PrimitiveSource } from '../core/types'
 
 export type ProcedureArgumentDefault = string | boolean
 
@@ -126,6 +126,12 @@ export type ProcedureCallInput = {
   value: PrimitiveSource<string | number | boolean>
 }
 
+export interface ProcedureDefinition<
+  T extends ProcedureProc[] = ProcedureProc[],
+> extends HikkakuBlock {
+  reference: ProcedureDefinitionReference<T>
+}
+
 type ReferencesByProcs<T extends ProcedureProc[]> = {
   [K in OnlyArgProc<T[number]>['name']]: OnlyArgProc<T[number]> extends {
     type: infer U
@@ -163,7 +169,7 @@ export const defineProcedure = <T extends ProcedureProc[]>(
    * This can make the procedure run faster, but the screen will not update until the procedure is done.
    */
   warp = false,
-) => {
+): ProcedureDefinition<T> => {
   const proccode = proclist
     .map((proc) => {
       switch (proc.type) {
@@ -258,7 +264,7 @@ export const defineProcedure = <T extends ProcedureProc[]>(
 /**
  * Calls a custom procedure.
  *
- * Input: either (`proccode`, `argumentIds`, `inputs`, `warp`) or (`reference`, `inputsByReference`, `warp`).
+ * Input: either (`proccode`, `argumentIds`, `inputs`, `warp`) or (`definitionOrReference`, `inputsByReference`, `warp`).
  * Output: Scratch statement block definition that is appended to the current script stack.
  *
  * @param proccodeOrReference See function signature for accepted input values.
@@ -274,7 +280,10 @@ export const defineProcedure = <T extends ProcedureProc[]>(
  * ```
  */
 export const callProcedure = (
-  proccodeOrReference: string | ProcedureDefinitionReference,
+  proccodeOrReference:
+    | string
+    | ProcedureDefinitionReference
+    | ProcedureDefinition,
   argumentIdsOrInputs:
     | string[]
     | ProcedureCallInput[]
@@ -294,12 +303,15 @@ export const callProcedure = (
     inputs = (typeof inputsOrWarp === 'object' ? inputsOrWarp : undefined) ?? {}
     warp = typeof inputsOrWarp === 'boolean' ? inputsOrWarp : warp
   } else {
-    proccode = proccodeOrReference.proccode
-    argumentIds = proccodeOrReference.argumentids
+    const procedureReference =
+      'reference' in proccodeOrReference
+        ? proccodeOrReference.reference
+        : proccodeOrReference
+
+    proccode = procedureReference.proccode
+    argumentIds = procedureReference.argumentids
     warp =
-      typeof inputsOrWarp === 'boolean'
-        ? inputsOrWarp
-        : proccodeOrReference.warp
+      typeof inputsOrWarp === 'boolean' ? inputsOrWarp : procedureReference.warp
 
     if (
       Array.isArray(argumentIdsOrInputs) &&

--- a/packages/skill/hikkaku/rules/blocks/procedures.md
+++ b/packages/skill/hikkaku/rules/blocks/procedures.md
@@ -80,7 +80,7 @@ defineProcedure(list as any, () => {}, undefined as any, undefined as any)
 
 Calls a custom procedure.
 
-Input: either (`proccode`, `argumentIds`, `inputs`, `warp`) or (`reference`, `inputsByReference`, `warp`).
+Input: either (`proccode`, `argumentIds`, `inputs`, `warp`) or (`definitionOrReference`, `inputsByReference`, `warp`).
 
 Output: Scratch statement block definition that is appended to the current script stack.
 

--- a/packages/skill/hikkaku/rules/custom-blocks.md
+++ b/packages/skill/hikkaku/rules/custom-blocks.md
@@ -64,7 +64,7 @@ const greet = defineProcedure([
   procedureBoolean('excited'),
 ])
 
-callProcedure(greet.reference, [
+callProcedure(greet, [
   { reference: greet.reference.arguments.name, value: 'Ada' },
   { reference: greet.reference.arguments.excited, value: true },
 ])


### PR DESCRIPTION
### Motivation
- 定義ブロックの返り値に手続き参照を返して、呼び出し時に名前やID配列を手動で同期する必要を無くし、参照ベースで安全に呼び出せるようにするためです。

### Description
- `ProcedureDefinitionReference` と `ProcedureCallInput` 型を追加して定義の proccode / argumentids / warp / 引数参照を保持する `reference` を提供するようにしました。
- `defineProcedure` は従来の定義ブロックを返す挙動は保ちつつ、返り値に `reference` を含めて呼び出し用情報を型付きで取得できるようにしました。
- `callProcedure` を拡張して、従来の `(proccode, argumentIds, inputs, warp)` 形式と、`defineProcedure(...).reference` を直接渡す参照ベース形式（`[{ reference, value }, ...]` または入力オブジェクト）を受け付けるようにしました。
- ドキュメントと skill ドキュメント（`docs/guides/custom-blocks.md`、`docs/reference/blocks/procedures.md`、`packages/skill/hikkaku/rules/*`）を更新して参照ベース呼び出しを推奨し、低レベル呼び出しは互換性のため残しました。

### Testing
- `bun run typecheck` を実行し全パッケージの型チェックは成功しました。 
- 変更ファイルに対して `bunx biome format` を適用および個別チェックを行い問題を修正・クリアしました。 
- ワークスペース全体で `bunx biome check .` を実行したところ、今回の変更箇所とは無関係な broken symlink や既存の未使用 import 等の既存問題によりチェックが失敗しましたが、本変更の型/フォーマット整合性は上記のコマンドで検証済みです.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b38b4219c8332880a7e783c319079)