### PR TITLE
feat: 変数定義で .get()/.set() を使えるようにする

### DIFF
--- a/docs/guides/variable.md
+++ b/docs/guides/variable.md
@@ -5,15 +5,15 @@ Variables and lists are created per target (sprite or stage) and then used in da
 ## Variables
 
 ```ts
-import { changeVariableBy, getVariable, setVariableTo, whenFlagClicked } from 'hikkaku/blocks'
+import { changeVariableBy, whenFlagClicked } from 'hikkaku/blocks'
 
 const score = sprite.createVariable('score', 0)
 
 sprite.run(() => {
   whenFlagClicked(() => {
-    setVariableTo(score, 0)
+    score.set(0)
     changeVariableBy(score, 1)
-    getVariable(score)
+    score.get()
   })
 })
 ```

--- a/packages/hikkaku/src/core/project.ts
+++ b/packages/hikkaku/src/core/project.ts
@@ -1,5 +1,6 @@
 import type * as sb3 from 'sb3-types'
-import { createBlocks } from './composer'
+import { fromPrimitiveSource } from './block-helper'
+import { block, createBlocks, valueBlock } from './composer'
 import type { Monitor } from './monitors'
 import {
   cloneMonitor,
@@ -12,7 +13,7 @@ import type {
   CreateVariableOptions,
   ListReference,
   SoundReference,
-  VariableReference,
+  VariableDefinition,
 } from './types'
 
 let nextAssetId = 0
@@ -86,7 +87,7 @@ export class Target<IsStage extends boolean = boolean> {
     name: string,
     defaultValue: sb3.ScalarVal = 0,
     isCloudVariableOrOptions?: boolean | CreateVariableOptions,
-  ): VariableReference {
+  ): VariableDefinition {
     const options =
       typeof isCloudVariableOrOptions === 'boolean'
         ? { isCloudVariable: isCloudVariableOrOptions }
@@ -112,6 +113,21 @@ export class Target<IsStage extends boolean = boolean> {
       id,
       name,
       type: 'variable',
+      get: () =>
+        valueBlock('data_variable', {
+          fields: {
+            VARIABLE: [name, id],
+          },
+        }),
+      set: (value) =>
+        block('data_setvariableto', {
+          inputs: {
+            VALUE: fromPrimitiveSource(value),
+          },
+          fields: {
+            VARIABLE: [name, id],
+          },
+        }),
     }
   }
 

--- a/packages/hikkaku/src/core/types.ts
+++ b/packages/hikkaku/src/core/types.ts
@@ -43,6 +43,11 @@ export interface VariableReference extends VariableBase {
   type: 'variable'
 }
 
+export interface VariableDefinition extends VariableReference {
+  get(): HikkakuBlock
+  set(value: PrimitiveSource<number | string>): HikkakuBlock
+}
+
 export interface ListReference extends VariableBase {
   type: 'list'
 }

--- a/packages/skill/hikkaku/rules/variable.md
+++ b/packages/skill/hikkaku/rules/variable.md
@@ -14,8 +14,6 @@ The returned references are then passed into data blocks from `hikkaku/blocks`.
 import { Project } from 'hikkaku'
 import {
   changeVariableBy,
-  getVariable,
-  setVariableTo,
   whenFlagClicked,
 } from 'hikkaku/blocks'
 
@@ -26,9 +24,9 @@ const score = sprite.createVariable('score', 0)
 
 sprite.run(() => {
   whenFlagClicked(() => {
-    setVariableTo(score, 0)
+    score.set(0)
     changeVariableBy(score, 1)
-    getVariable(score)
+    score.get()
   })
 })
 ```
@@ -94,6 +92,6 @@ sprite.run(() => {
 
 ## Notes
 
-* `createVariable(name, defaultValue?, isCloudVariableOrOptions?)` returns a `VariableReference`.
+* `createVariable(name, defaultValue?, isCloudVariableOrOptions?)` returns a `VariableDefinition` (`VariableReference` + `.get()` / `.set()` helpers).
 * `createList(name, defaultValue?, options?)` returns a `ListReference`.
 * Variable and list references are scoped to the target that created them (sprite or stage).


### PR DESCRIPTION
## 概要
- `createVariable()` の返り値に `.get()` / `.set()` ヘルパーを追加
- `VariableDefinition` 型を追加（`VariableReference` 互換を維持）
- 変数ガイドと skill ルールのサンプルを `.get()` / `.set()` 記法に更新

## 確認
- `bun fmt`
- `bun typecheck`
- `bun ref:build`