### PR TITLE
fix(create-hikkaku): default ref to create-hikkaku@<version>

### DIFF
--- a/packages/create-hikkaku/README.md
+++ b/packages/create-hikkaku/README.md
@@ -23,4 +23,5 @@ create-hikkaku [project-name] [options]
 --ref <git-tag>
 ```
 
-`--ref` 未指定時は `create-hikkaku` の `version` と同じ Git タグからテンプレートを取得します。
+`--ref` 未指定時は `create-hikkaku@<version>` 形式の Git タグ
+（例: `create-hikkaku@0.1.9`）からテンプレートを取得します。

--- a/packages/create-hikkaku/src/main.ts
+++ b/packages/create-hikkaku/src/main.ts
@@ -26,6 +26,7 @@ import pc from 'picocolors'
 
 const REPO_OWNER = 'pnsk-lab'
 const REPO_NAME = 'hikkaku'
+const CREATE_HIKKAKU_TAG_PREFIX = 'create-hikkaku@'
 const TEMPLATE_DIR_IN_REPO = ['examples', 'base']
 const DEFAULT_PROJECT_DIR = 'my-hikkaku-app'
 const SEMVER_PATTERN =
@@ -295,20 +296,20 @@ Options:
   --link-claude / --no-link-claude
                                Create CLAUDE.md -> AGENTS.md symlink
   --skills / --no-skills       Add hikkaku skills after scaffolding
-  --ref <git-tag>              GitHub tag to download (default: package version)
+  --ref <git-tag>              GitHub tag to download (default: create-hikkaku@<version>)
 `,
   )
 }
 
-const getDefaultTagFromPackageVersion = async () => {
+const getDefaultRefFromPackageVersion = async () => {
   const pkg = JSON.parse(await readFile(SELF_PACKAGE_JSON_PATH, 'utf8'))
   const version = typeof pkg.version === 'string' ? pkg.version.trim() : ''
   if (!version || !SEMVER_PATTERN.test(version)) {
     throw new Error(
-      `Invalid create-hikkaku version "${version}". Expected semver for default tag resolution.`,
+      `Invalid create-hikkaku version "${version}". Expected semver for default ref resolution.`,
     )
   }
-  return version
+  return `${CREATE_HIKKAKU_TAG_PREFIX}${version}`
 }
 
 const createPrompter = () => {
@@ -629,10 +630,10 @@ const main = async () => {
       warning('--link-claude was ignored because AGENTS.md is disabled')
     }
 
-    const ref = cli.ref ?? (await getDefaultTagFromPackageVersion())
+    const ref = cli.ref ?? (await getDefaultRefFromPackageVersion())
     log(
       `Template tag: ${pc.bold(ref)} ${pc.dim(
-        cli.ref ? '(from --ref)' : '(from create-hikkaku version)',
+        cli.ref ? '(from --ref)' : '(from create-hikkaku@<version>)',
       )}`,
     )
 


### PR DESCRIPTION
## 概要
- `create-hikkaku` のデフォルト参照タグを `create-hikkaku@<version>` 形式に変更
- `--ref` ヘルプ文言と README の説明を新しいタグ形式に更新
- 既定値ログ表示を `create-hikkaku@<version>` ベースに更新

## 変更詳細
- `packages/create-hikkaku/src/main.ts`
  - `CREATE_HIKKAKU_TAG_PREFIX` を追加
  - `getDefaultRefFromPackageVersion()` で `create-hikkaku@${version}` を返すよう変更
  - `--ref` オプション説明とログのデフォルト文言を更新
- `packages/create-hikkaku/README.md`
  - `--ref` 未指定時の挙動説明を新タグ形式に更新

## 確認
- `bun fmt`
- `bun typecheck`
- `bun ref:build`