### PR TITLE
ci: use bump type input in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,12 +73,29 @@ jobs:
             exit 1
           fi
 
-          package_json_path="packages/$package/package.json"
-          if [ ! -r "$package_json_path" ]; then
-            echo "package.json not found or not readable: $package_json_path"
-            exit 1
+          # Derive current version from latest tag for this package
+          # If no tags exist, fall back to package.json version
+          # Note: Uses git's version sorting which correctly handles semver including prereleases
+          latest_tag=$(git tag -l "$package@*" --sort=-version:refname | head -n1)
+          
+          if [ -n "$latest_tag" ]; then
+            # Extract version from tag (format: package@version)
+            current_version="${latest_tag#$package@}"
+            echo "Found latest tag: $latest_tag (version: $current_version)"
+          else
+            # No tags exist, use package.json version as starting point
+            package_json_path="packages/$package/package.json"
+            if [ ! -r "$package_json_path" ]; then
+              echo "package.json not found or not readable: $package_json_path"
+              exit 1
+            fi
+            current_version="$(node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.stdout.write(typeof pkg.version==='string'?pkg.version.trim():'')" "$package_json_path")"
+            if [ -z "$current_version" ]; then
+              echo "package.json does not contain a valid version field: $package_json_path"
+              exit 1
+            fi
+            echo "No existing tags found, using package.json version: $current_version"
           fi
-          current_version="$(node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.stdout.write(typeof pkg.version==='string'?pkg.version.trim():'')" "$package_json_path")"
 
           if ! [[ "$current_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)([.-][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid current package version: $current_version"


### PR DESCRIPTION
## Summary
- replace workflow_dispatch `version` input with `release_type` choice (`major`/`minor`/`patch`)
- derive next semver from package.json current version in publish workflow
- keep existing tag/release duplication checks and publish flow

## Verification
- bun fmt
- bun typecheck
- bun ref:build