### PR TITLE
vite-plugin-turbowarp-packagerのhikkaku参照先修正

### DIFF
--- a/packages/vite-plugin-turbowarp-packager/package.json
+++ b/packages/vite-plugin-turbowarp-packager/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@turbowarp/packager": "^3.11.0",
     "fflate": "^0.8.2",
-    "hikkaku": "workspace:*",
+    "hikkaku": "^0.2.0",
     "vite": "8.0.0-beta.13"
   }
 }


### PR DESCRIPTION
vite-plugin-turbowarp-packagerがローカルのworkspaceを参照しているためパッケージマネージャでインストールできません

[ドキュメント該当箇所](https://github.com/pnsk-lab/hikkaku/blob/main/packages/vite-plugin-turbowarp-packager/README.md#installation)

Error:
```bash
username@devicename:~/code/fumikun/hikkaku-project$ bun add -D vite-plugin-turbowarp-packager
bun add v1.1.38 (bf2f153f)
error: Workspace dependency "hikkaku" not found

Searched in "./*"

Workspace documentation: https://bun.sh/docs/install/workspaces

error: hikkaku@workspace:* failed to resolve

```