### PR TITLE
feat(docs): add favicon and Open Graph / Twitter meta tags

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -45,6 +45,52 @@ export default withTwoslashInlineCache(
     description: 'Write Scratch projects in TypeScript',
     lang: 'en-US',
     base: '/hikkaku/',
+    head: [
+      [
+        'link',
+        {
+          rel: 'icon',
+          type: 'image/svg+xml',
+          href: '/hikkaku/assets/logo.svg',
+        },
+      ],
+      ['meta', { property: 'og:type', content: 'website' }],
+      ['meta', { property: 'og:title', content: 'Hikkaku' }],
+      [
+        'meta',
+        {
+          property: 'og:description',
+          content: 'Write Scratch projects in TypeScript',
+        },
+      ],
+      [
+        'meta',
+        { property: 'og:url', content: 'https://pnsk-lab.github.io/hikkaku/' },
+      ],
+      [
+        'meta',
+        {
+          property: 'og:image',
+          content: 'https://pnsk-lab.github.io/hikkaku/assets/logo.svg',
+        },
+      ],
+      ['meta', { name: 'twitter:card', content: 'summary' }],
+      ['meta', { name: 'twitter:title', content: 'Hikkaku' }],
+      [
+        'meta',
+        {
+          name: 'twitter:description',
+          content: 'Write Scratch projects in TypeScript',
+        },
+      ],
+      [
+        'meta',
+        {
+          name: 'twitter:image',
+          content: 'https://pnsk-lab.github.io/hikkaku/assets/logo.svg',
+        },
+      ],
+    ],
     markdown: {
       codeTransformers: [],
     },


### PR DESCRIPTION
### Motivation
- Add a favicon using the existing logo to improve site identification and browser UX.
- Provide Open Graph and Twitter Card metadata so shared links render proper titles, descriptions, and images on social platforms.

### Description
- Add a `head` array to `docs/.vitepress/config.ts` that includes a favicon link to `/hikkaku/assets/logo.svg`.
- Add Open Graph meta tags (`og:type`, `og:title`, `og:description`, `og:url`, `og:image`) pointing to the site and logo URL.
- Add Twitter Card meta tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`).
- This change addresses issue `#73`.

### Testing
- Ran `bun fmt`, which completed successfully and applied formatting fixes.
- Ran `bun typecheck`, which completed successfully (typecheck tasks succeeded).
- Ran `bun ref:build`, which completed successfully and updated generated docs outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ec9641d048332b64c63218b7599ff)