### PR TITLE
refactor(docs): centralize BASE and DOMAIN constants for VitePress config

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -39,12 +39,58 @@ const blocksSidebar = [
 
 const withTwoslashInlineCache = createTwoslashWithInlineCache({})
 
+const BASE = '/hikkaku/'
+const DOMAIN = 'https://pnsk-lab.github.io'
+
 export default withTwoslashInlineCache(
   defineConfig({
     title: 'Hikkaku',
     description: 'Write Scratch projects in TypeScript',
     lang: 'en-US',
-    base: '/hikkaku/',
+    base: BASE,
+    head: [
+      [
+        'link',
+        {
+          rel: 'icon',
+          type: 'image/svg+xml',
+          href: `${BASE}assets/logo.svg`,
+        },
+      ],
+      ['meta', { property: 'og:type', content: 'website' }],
+      ['meta', { property: 'og:title', content: 'Hikkaku' }],
+      [
+        'meta',
+        {
+          property: 'og:description',
+          content: 'Write Scratch projects in TypeScript',
+        },
+      ],
+      ['meta', { property: 'og:url', content: `${DOMAIN}${BASE}` }],
+      [
+        'meta',
+        {
+          property: 'og:image',
+          content: `${DOMAIN}${BASE}assets/logo.svg`,
+        },
+      ],
+      ['meta', { name: 'twitter:card', content: 'summary' }],
+      ['meta', { name: 'twitter:title', content: 'Hikkaku' }],
+      [
+        'meta',
+        {
+          name: 'twitter:description',
+          content: 'Write Scratch projects in TypeScript',
+        },
+      ],
+      [
+        'meta',
+        {
+          name: 'twitter:image',
+          content: `${DOMAIN}${BASE}assets/logo.svg`,
+        },
+      ],
+    ],
     markdown: {
       codeTransformers: [],
     },


### PR DESCRIPTION
### Motivation
- Reduce hard-coded site base and domain strings in VitePress config to make favicon and OGP/Twitter metadata easier to maintain and address an inline request to avoid hardcoding.

### Description
- Add `const BASE = '/hikkaku/'` and `const DOMAIN = 'https://pnsk-lab.github.io'` to `docs/.vitepress/config.ts` and use `BASE` for the `base` setting.
- Replace hard-coded favicon, Open Graph `url`/`image`, and Twitter `image` values to use template strings like ```${BASE}assets/logo.svg``` and ```${DOMAIN}${BASE}``` while keeping existing metadata values unchanged.

### Testing
- Ran `bun fmt`, `bun typecheck`, and `bun ref:build`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ec9641d048332b64c63218b7599ff)