### PR TITLE
fix(docs/playground): refresh playground blocks on sprite update

### DIFF
--- a/docs/.vitepress/components/Playground.vue
+++ b/docs/.vitepress/components/Playground.vue
@@ -335,7 +335,7 @@ const selectedTargetLabel = computed(
 
 const selectedTargetBlocks = computed<PackedBlockMap | null>(() => {
   const blocks = selectedTarget.value?.blocks
-  return isPackedBlockMap(blocks) ? blocks : null
+  return isPackedBlockMap(blocks) ? { ...blocks } : null
 })
 
 watch(


### PR DESCRIPTION
## Summary\n- Ensure playground sprite block panel gets a fresh block map reference so Blockly re-renders when sprite changes.\n- Fix cases where target updates did not reflect immediately in the block editor.\n\n## Changes\n- Updated docs/.vitepress/components/Playground.vue\n  - selectedTargetBlocks now returns a cloned PackedBlockMap instead of passing the original object reference.